### PR TITLE
Improve v2 report interactivity

### DIFF
--- a/src/agent_report_v2_refined.py
+++ b/src/agent_report_v2_refined.py
@@ -94,6 +94,29 @@ class AgentIntelligenceReportV2Refined:
             color: #6b7280;
             margin-top: 5px;
         }
+
+        /* Filter Bar */
+        .filter-bar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+        .filter-bar select,
+        .filter-bar input {
+            padding: 6px 10px;
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            font-size: 14px;
+        }
+        .filter-bar button {
+            background: #4f46e5;
+            color: #fff;
+            border: none;
+            padding: 6px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+        }
         
         /* Opportunity Cards */
         .opportunities-grid {
@@ -108,6 +131,7 @@ class AgentIntelligenceReportV2Refined:
             box-shadow: 0 2px 4px rgba(0,0,0,0.05);
             border-left: 4px solid #10b981;
             transition: transform 0.2s;
+            position: relative;
         }
         .opportunity-card:hover {
             transform: translateY(-2px);
@@ -155,6 +179,36 @@ class AgentIntelligenceReportV2Refined:
             font-weight: 600;
             margin-top: 5px;
             color: #111827;
+        }
+
+        .progress-bar {
+            height: 6px;
+            background: #e5e7eb;
+            border-radius: 3px;
+            overflow: hidden;
+            margin-top: 15px;
+        }
+        .progress-fill {
+            height: 100%;
+            background: #10b981;
+        }
+
+        .toggle-btn {
+            background: transparent;
+            border: none;
+            color: #3b82f6;
+            cursor: pointer;
+            margin-top: 10px;
+            font-size: 14px;
+        }
+        .extra-details {
+            display: none;
+            margin-top: 15px;
+            border-top: 1px dashed #d1d5db;
+            padding-top: 15px;
+        }
+        .sparkline {
+            margin-top: 5px;
         }
         
         /* Action Timeline */
@@ -261,9 +315,9 @@ class AgentIntelligenceReportV2Refined:
         }
         
         @media print {
-            body { background: white; }
+            body { background: white; font-size: 12px; line-height: 1.3; }
             .container { max-width: 100%; }
-            .opportunity-card { break-inside: avoid; }
+            .opportunity-card { break-inside: avoid; margin-bottom: 20px; }
             .reminder-btn { display: none; }
         }
     </style>
@@ -288,7 +342,22 @@ class AgentIntelligenceReportV2Refined:
             </div>
         </div>
         {% endif %}
-        
+
+        <div class="filter-bar">
+            <input type="text" id="carrierFilter" placeholder="Filter carrier">
+            <select id="productFilter">
+                <option value="">All Products</option>
+                {% for prod in product_options %}
+                <option value="{{ prod }}">{{ prod }}</option>
+                {% endfor %}
+            </select>
+            <select id="sortFilter">
+                <option value="days">Sort by Days Until</option>
+                <option value="increase">Sort by Increase</option>
+            </select>
+            <button onclick="applyFilter()">Apply</button>
+        </div>
+
         <div class="summary-section">
             <h2>Market Summary</h2>
             <div class="summary-grid">
@@ -314,7 +383,7 @@ class AgentIntelligenceReportV2Refined:
         <h2 style="margin: 30px 0 20px;">Recent Rate Increases</h2>
         <div class="opportunities-grid">
             {% for opp in opportunities %}
-            <div class="opportunity-card">
+            <div class="opportunity-card" data-carrier="{{ opp.competitor|lower }}" data-product="{{ opp.product_lines }}" data-increase="{{ opp.rate_increase }}" data-days="{{ opp.days_until }}">
                 <div class="opportunity-header">
                     <div>
                         <div class="competitor-name">{{ opp.competitor }}</div>
@@ -337,6 +406,17 @@ class AgentIntelligenceReportV2Refined:
                     <div class="detail-item">
                         <div class="detail-label">Product Lines</div>
                         <div class="detail-value">{{ opp.product_lines }}</div>
+                    </div>
+                </div>
+                <div class="progress-bar"><div class="progress-fill" style="width: {{ opp.urgency_percent }}%; background: {{ opp.urgency_color }};"></div></div>
+                <button class="toggle-btn" onclick="toggleDetails(this)">View Details</button>
+                <div class="extra-details">
+                    <div class="detail-item">Filings: {{ opp.filing_count }}</div>
+                    <div class="detail-item">Past Increases:
+                        <span class="sparkline" data-points="{{ opp.recent_changes|join(',') }}"></span>
+                    </div>
+                    <div class="detail-item" style="margin-top:10px; font-size:13px; color:#374151;">
+                        {{ opp.call_script }}
                     </div>
                 </div>
             </div>
@@ -378,17 +458,85 @@ class AgentIntelligenceReportV2Refined:
     
     <script>
         function saveReminder(carrier, date) {
-            // Simple simulation - in production this would integrate with calendar
-            event.target.textContent = '✓ Saved';
-            event.target.classList.add('saved');
-            
-            // Show confirmation
+            const btn = event.target;
+            btn.textContent = '✓ Saved';
+            btn.classList.add('saved');
+
+            const yyyyMMdd = new Date(date + ' 00:00').toISOString().slice(0,10).replace(/-/g, '');
+            const ics = [
+                'BEGIN:VCALENDAR',
+                'VERSION:2.0',
+                'BEGIN:VEVENT',
+                'SUMMARY:Reach out to ' + carrier + ' customers',
+                'DTSTART;VALUE=DATE:' + yyyyMMdd,
+                'DTEND;VALUE=DATE:' + yyyyMMdd,
+                'END:VEVENT',
+                'END:VCALENDAR'
+            ].join('\n');
+            const blob = new Blob([ics], {type: 'text/calendar'});
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = carrier.replace(/\\s+/g,'_') + '_' + yyyyMMdd + '.ics';
+            link.click();
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
+
             const confirmation = document.createElement('div');
             confirmation.style.cssText = 'position: fixed; top: 20px; right: 20px; background: #10b981; color: white; padding: 16px 24px; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 1000;';
-            confirmation.textContent = `Reminder set for ${carrier} on ${date}`;
+            confirmation.textContent = `Reminder downloaded for ${carrier}`;
             document.body.appendChild(confirmation);
-            
             setTimeout(() => confirmation.remove(), 3000);
+        }
+
+        function toggleDetails(btn) {
+            const details = btn.nextElementSibling;
+            if (details.style.display === 'block') {
+                details.style.display = 'none';
+                btn.textContent = 'View Details';
+            } else {
+                details.style.display = 'block';
+                btn.textContent = 'Hide Details';
+                renderSparklines();
+            }
+        }
+
+        function renderSparklines() {
+            document.querySelectorAll('.sparkline').forEach(el => {
+                if (el.dataset.rendered) return;
+                const pts = el.dataset.points.split(',').map(parseFloat);
+                if (!pts.length) return;
+                const max = Math.max(...pts);
+                const min = Math.min(...pts);
+                const w = 60, h = 20;
+                const step = w / (pts.length - 1);
+                let d = '';
+                pts.forEach((p,i) => {
+                    const x = i * step;
+                    const y = h - ((p - min) / (max - min || 1)) * h;
+                    d += (i ? 'L':'M') + x + ' ' + y + ' ';
+                });
+                el.innerHTML = `<svg width="${w}" height="${h}"><path d="${d}" stroke="#3b82f6" stroke-width="2" fill="none"/></svg>`;
+                el.dataset.rendered = true;
+            });
+        }
+
+        function applyFilter() {
+            const carrier = document.getElementById('carrierFilter').value.toLowerCase();
+            const product = document.getElementById('productFilter').value;
+            const sort = document.getElementById('sortFilter').value;
+            const cards = Array.from(document.querySelectorAll('.opportunity-card'));
+            cards.forEach(card => {
+                const cMatch = !carrier || card.dataset.carrier.includes(carrier);
+                const pMatch = !product || card.dataset.product.includes(product);
+                card.style.display = cMatch && pMatch ? 'block' : 'none';
+            });
+            if (sort === 'increase') {
+                cards.sort((a,b)=>parseFloat(b.dataset.increase)-parseFloat(a.dataset.increase));
+            } else {
+                cards.sort((a,b)=>parseInt(a.dataset.days)-parseInt(b.dataset.days));
+            }
+            const grid = document.querySelector('.opportunities-grid');
+            cards.forEach(c=>grid.appendChild(c));
         }
     </script>
 </body>
@@ -413,7 +561,8 @@ class AgentIntelligenceReportV2Refined:
                 SUM(Policyholders_Affected_Number) as policies_affected,
                 COUNT(*) as filing_count,
                 CAST(DATEDIFF('day', CURRENT_DATE, MAX(Effective_Date)) AS INTEGER) as days_until,
-                STRING_AGG(DISTINCT Product_Line, ', ') as product_lines
+                STRING_AGG(DISTINCT Product_Line, ', ') as product_lines,
+                ARRAY_SLICE(array_agg(ROUND(Premium_Change_Number * 100, 1) ORDER BY Effective_Date DESC), 1, 3) as recent_changes
             FROM filings
             WHERE State = '{state}'
             AND Company NOT LIKE '%{agent_carrier}%'
@@ -454,6 +603,7 @@ class AgentIntelligenceReportV2Refined:
         opportunities = []
         timeline = []
         urgent_count = 0
+        product_set = set()
         
         for _, opp in opportunities_df.iterrows():
             if opp['days_until'] <= 30:
@@ -463,6 +613,11 @@ class AgentIntelligenceReportV2Refined:
             product_lines = opp['product_lines'] if pd.notna(opp['product_lines']) else 'Auto'
             if len(product_lines) > 30:
                 product_lines = product_lines[:27] + '...'
+            product_set.update([p.strip() for p in product_lines.split(',')])
+
+            urgency_percent = max(0, (90 - opp['days_until']) / 90 * 100)
+            urgency_color = '#dc2626' if opp['days_until'] <= 30 else '#10b981'
+            recent_changes = opp['recent_changes'] if isinstance(opp['recent_changes'], list) else []
             
             opp_data = {
                 'competitor': self._clean_company_name(opp['Company']),
@@ -470,7 +625,12 @@ class AgentIntelligenceReportV2Refined:
                 'effective_date': pd.to_datetime(opp['effective_date']).strftime('%B %d, %Y'),
                 'days_until': int(opp['days_until']) if opp['days_until'] >= 0 else 0,
                 'policies_affected': f"{int(opp['policies_affected']):,}" if pd.notna(opp['policies_affected']) and opp['policies_affected'] > 0 else "N/A",
-                'product_lines': product_lines
+                'product_lines': product_lines,
+                'filing_count': int(opp['filing_count']),
+                'recent_changes': recent_changes,
+                'urgency_percent': round(urgency_percent, 1),
+                'urgency_color': urgency_color,
+                'call_script': f"Call former customers when {self._clean_company_name(opp['Company'])} raises rates {round(opp['avg_increase'],1)}%."
             }
             opportunities.append(opp_data)
             
@@ -502,7 +662,8 @@ class AgentIntelligenceReportV2Refined:
             'estimated_policies': f"{int(total_policies):,}" if total_policies > 0 else "5,000+",
             'timeline': timeline[:6],  # Next 6 actions
             'timestamp': datetime.now().strftime('%I:%M %p'),
-            'data_freshness': datetime.now().strftime('%B %d, %Y')
+            'data_freshness': datetime.now().strftime('%B %d, %Y'),
+            'product_options': sorted(product_set)
         }
         
         return self.report_template.render(**template_data)


### PR DESCRIPTION
## Summary
- add filter bar for opportunities
- show progress bar and toggleable extra details for each competitor card
- generate downloadable ICS files for outreach reminders
- include past rate increases with sparklines
- tweak print styles

## Testing
- `python run_tests.py`