### PR TITLE
Fix DB init and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ git clone https://github.com/USERNAME/insurance-analytics.git
 cd insurance-analytics
 ```
 
+2. Activate the provided virtual environment (all dependencies are pre-installed)
+```bash
+source venv/bin/activate
+```
+
+### Creating or Syncing the Database
+
+The project stores data in a DuckDB file at `data/insurance_filings.db`. If the
+`data` folder is missing, it will be created automatically when you run the sync
+tool.
+
+1. Set your Airtable credentials as environment variables (see
+   `src/config.py` for variable names).
+2. Run the sync script to create the database and load data:
+```bash
+python test_sync.py
+```
+Follow the prompt to run a full sync. This will initialize the database schema
+and pull all records from Airtable.
+
 ## CSS Development Workflow
 
 A development environment is provided in the `dev/` folder for quickly iterating on the report styling.
@@ -34,3 +54,19 @@ A development environment is provided in the `dev/` folder for quickly iterating
 3. Once satisfied, run `./embed_css_in_template.py` to embed the CSS back into `src/agent_report_v2.py`.
 
 The script replaces the contents of the `<style>` block in the template so the production version remains a single file.
+
+## Running Analytics & Health Checks
+
+Once your database is populated you can run various analytics directly from the
+command line.
+
+```bash
+# Generate the primary agent report
+python -m src.agent_report_v2_refined > reports/latest_report.html
+
+# Run basic health checks on the data
+python -m src.data_health_checker
+```
+
+The health check outputs missing states and duplicate record information so you
+can verify the integrity of your filings data.

--- a/src/database.py
+++ b/src/database.py
@@ -2,23 +2,28 @@ import duckdb
 import pandas as pd
 from datetime import datetime
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
+
 class DatabaseManager:
-    def __init__(self, db_path='data/insurance_filings.db'):
+    def __init__(self, db_path="data/insurance_filings.db"):
         self.db_path = db_path
+        # Ensure the directory for the database exists
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
         self.init_database()
-    
+
     def get_connection(self):
         return duckdb.connect(self.db_path)
-    
+
     def init_database(self):
         """Initialize database with proper schema"""
         conn = self.get_connection()
-        
+
         # Create main table matching your Airtable fields
-        conn.execute("""
+        conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS filings (
                 Record_ID VARCHAR PRIMARY KEY,
                 Company VARCHAR,
@@ -44,16 +49,17 @@ class DatabaseManager:
                 Created_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 Updated_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
-        """)
-        
+        """
+        )
+
         # Create indexes for performance
         conn.execute("CREATE INDEX IF NOT EXISTS idx_state_product ON filings(State, Product_Line)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_company ON filings(Company, Subsidiary)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_effective_date ON filings(Effective_Date)")
-        
+
         conn.close()
         logger.info("Database initialized successfully")
-    
+
     def get_schema_context(self):
         """Return schema information for LLM context"""
         return """


### PR DESCRIPTION
## Summary
- ensure database directory is created before initializing DuckDB
- explain how to create/sync the database
- document analytics and health check commands

## Testing
- `python format_code.py`
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'pandas')*