### PR TITLE
Fix config import

### DIFF
--- a/src/airtable_sync.py
+++ b/src/airtable_sync.py
@@ -3,8 +3,8 @@ from pyairtable import Table
 import duckdb
 from datetime import datetime
 import logging
-from config import Config
-from database import DatabaseManager
+from src.config import Config
+from src.database import DatabaseManager
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- fix config import path in `airtable_sync`

## Testing
- `python3 run_tests.py` *(fails: ModuleNotFoundError: No module named 'pandas')*