### PR TITLE
Add month option for state newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This project now includes a monthly HTML newsletter template for any U.S. state.
 ### Generating a Report
 
 ```bash
-python -m src.reports.state_newsletter Illinois > reports/illinois.html
+python -m src.reports.state_newsletter Illinois --month 2024-03 > reports/illinois_march_2024.html
 ```
 
 ### Data Flow
@@ -97,4 +97,4 @@ python -m src.reports.state_newsletter Illinois > reports/illinois.html
 Database (DuckDB) --> state_newsletter.py --> templates/state_newsletter.html --> HTML output
 ```
 
-Reports are generated for a single state at a time. The initial test case uses **Illinois** but all 50 states are supported if data is present.
+Reports are generated for a single state at a time. Use the optional `--month` flag to target a specific month (`YYYY-MM`). The output file name now includes the state and month for clarity.

--- a/src/reports/state_newsletter.py
+++ b/src/reports/state_newsletter.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import logging
 from jinja2 import Environment, FileSystemLoader
 import duckdb
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -33,20 +34,45 @@ class StateNewsletterReport:
         self.env = Environment(loader=FileSystemLoader(template_dir))
         self.template = self.env.get_template("state_newsletter.html")
 
+    @staticmethod
+    def _parse_month(month_str: Optional[str]) -> Tuple[datetime, datetime, str]:
+        """Return (start_date, end_date, label) for a YYYY-MM string or None."""
+        if month_str:
+            try:
+                start = datetime.strptime(month_str, "%Y-%m")
+            except ValueError:
+                try:
+                    start = datetime.strptime(month_str, "%Y-%m-%d")
+                except ValueError:
+                    start = datetime.now().replace(day=1)
+        else:
+            start = datetime.now().replace(day=1)
+
+        # Compute first day of next month
+        if start.month == 12:
+            end = datetime(start.year + 1, 1, 1)
+        else:
+            end = datetime(start.year, start.month + 1, 1)
+
+        label = start.strftime("%B %Y")
+        return start, end, label
+
     def _get_connection(self):
         return duckdb.connect(self.db_path)
 
     def _get_carrier_count(self, conn):
         """Return unique carrier count or None on failure."""
         try:
-            result = conn.execute("SELECT COUNT(DISTINCT Company) FROM filings").fetchone()
+            result = conn.execute(
+                "SELECT COUNT(DISTINCT Company) FROM filings"
+            ).fetchone()
             return int(result[0]) if result else None
         except Exception as exc:
             logger.error("Carrier count query failed: %s", exc)
             return None
 
-    def _market_summary(self, state: str):
-        """Return summary metrics for a state"""
+    def _market_summary(self, state: str, start: datetime, end: datetime):
+        """Return summary metrics for a state within a month"""
         query = f"""
             SELECT
                 COUNT(DISTINCT Company) FILTER (WHERE Premium_Change_Number > 0) AS companies,
@@ -54,12 +80,12 @@ class StateNewsletterReport:
                 COALESCE(SUM(Policyholders_Affected_Number), 0) AS policies
             FROM filings
             WHERE State = ?
-                AND Effective_Date >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL '1 month')
-                AND Effective_Date < DATE_TRUNC('month', CURRENT_DATE)
+                AND Effective_Date >= ?
+                AND Effective_Date < ?
         """
         conn = self._get_connection()
         try:
-            result = conn.execute(query, [state]).fetchone()
+            result = conn.execute(query, [state, start, end]).fetchone()
         except Exception as exc:
             logger.error("Market summary query failed: %s", exc)
             conn.close()
@@ -76,38 +102,47 @@ class StateNewsletterReport:
             "policies_affected": format_number_short(policies or 0),
         }
 
-    def _rate_cards(self, state: str, limit: int = 3):
+    def _rate_cards(self, state: str, start: datetime, end: datetime, limit: int = 3):
         """Return top rate changes for a state"""
         query = f"""
             SELECT
                 Company,
+                Subsidiary,
+                Impact_Score,
                 ROUND(MAX(Premium_Change_Number)*100,1) AS change_pct,
                 COALESCE(SUM(Policyholders_Affected_Number),0) AS policies,
                 MAX(Effective_Date) AS effective_date
             FROM filings
             WHERE State = ?
-                AND Effective_Date >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL '1 month')
-                AND Effective_Date < DATE_TRUNC('month', CURRENT_DATE)
-            GROUP BY Company
-            ORDER BY change_pct DESC
+                AND Effective_Date >= ?
+                AND Effective_Date < ?
+            GROUP BY Company, Subsidiary, Impact_Score
+            ORDER BY Impact_Score DESC NULLS LAST, change_pct DESC
             LIMIT {limit}
         """
         conn = self._get_connection()
-        rows = conn.execute(query, [state]).fetchall()
+        rows = conn.execute(query, [state, start, end]).fetchall()
         conn.close()
         cards = []
         for row in rows:
-            company, pct, policies, eff = row
+            company, subsidiary, impact, pct, policies, eff = row
             color = "#ef4444" if (pct or 0) >= 0 else "#10b981"
             effective = "-"
             if eff:
                 try:
-                    effective = datetime.strptime(str(eff), "%Y-%m-%d").strftime("%b %d")
+                    effective = datetime.strptime(str(eff), "%Y-%m-%d").strftime(
+                        "%b %d"
+                    )
                 except Exception:
                     effective = "-"
+            display_name = (
+                company
+                if company and company != "Not specified in document"
+                else subsidiary
+            )
             cards.append(
                 {
-                    "company": company or "N/A",
+                    "company": display_name or "N/A",
                     "change_pct": pct if pct is not None else 0,
                     "policies": format_number_short(policies or 0),
                     "effective_date": effective,
@@ -138,22 +173,30 @@ class StateNewsletterReport:
         return {
             "total_filings": format_number_short(total_filings),
             "total_policyholders": format_number_short(policyholders),
-            "carriers_tracked": format_number_short(carriers) if carriers is not None else "0",
+            "carriers_tracked": (
+                format_number_short(carriers) if carriers is not None else "0"
+            ),
         }
 
-    def generate(self, state: str):
-        summary = self._market_summary(state) or {
+    def generate(self, state: str, month: Optional[str] = None):
+        start, end, label = self._parse_month(month)
+
+        summary = self._market_summary(state, start, end) or {
             "companies": 0,
             "avg_increase_pct": 0,
             "policies_affected": "0",
         }
-        cards = self._rate_cards(state) or []
+        cards = self._rate_cards(state, start, end) or []
         stats = self._overall_stats()
         if not stats:
-            stats = {"total_filings": "0", "total_policyholders": "0", "carriers_tracked": "0"}
-        month = datetime.now().strftime("%B %Y")
+            stats = {
+                "total_filings": "0",
+                "total_policyholders": "0",
+                "carriers_tracked": "0",
+            }
+        month_label = label
         html = self.template.render(
-            report_month=month,
+            report_month=month_label,
             state=state,
             summary=summary,
             rate_cards=cards,
@@ -171,11 +214,20 @@ class StateNewsletterReport:
 
 
 if __name__ == "__main__":
-    import sys
+    import argparse
 
     logging.basicConfig(level=logging.INFO)
-    state_arg = sys.argv[1] if len(sys.argv) > 1 else "Illinois"
+
+    parser = argparse.ArgumentParser(description="Generate a state newsletter")
+    parser.add_argument("state", help="Target state")
+    parser.add_argument(
+        "--month", dest="month", help="Target month YYYY-MM", required=False
+    )
+    args = parser.parse_args()
+
     report = StateNewsletterReport()
-    html = report.generate(state_arg)
-    outfile = report.save(html, f"{state_arg.lower()}_report.html")
+    html = report.generate(args.state, args.month)
+    start, _, _ = report._parse_month(args.month)
+    filename = f"{args.state.lower()}_{start.strftime('%B_%Y').lower()}.html"
+    outfile = report.save(html, filename)
     print(f"Generated {outfile}")


### PR DESCRIPTION
## Summary
- enable selecting the month when generating state newsletters
- add parent company fallback logic
- sort newsletter cards by impact score
- include month and year in output filename
- document new month parameter

## Testing
- `venv/bin/python run_tests.py`