### PR TITLE
Fix newsletter import path

### DIFF
--- a/serff_analytics/reports/state_newsletter.py
+++ b/serff_analytics/reports/state_newsletter.py
@@ -4,7 +4,8 @@ import logging
 from jinja2 import Environment, FileSystemLoader
 import duckdb
 from typing import Optional, Tuple
-from src.database import get_month_boundaries
+# get_month_boundaries lives in the db utilities module
+from serff_analytics.db.utils import get_month_boundaries
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- use get_month_boundaries from db utilities

## Testing
- `python scripts/run_tests.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_683db37465a4832b917a00530dd10170