### PR TITLE
Improve DB initialization handling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,11 @@ python scripts/verify_deps.py
 
 The project stores data in a DuckDB file at `data/insurance_filings.db`. If the
 `data` folder is missing, it will be created automatically when you run the sync
-tool.
+tool. You can also create an empty database using the helper script:
+
+```bash
+python scripts/init_database.py
+```
 
 1. Set your Airtable credentials as environment variables (see
    `serff_analytics/config.py` for variable names).
@@ -98,3 +102,7 @@ Database (DuckDB) --> state_newsletter.py --> templates/state_newsletter.html --
 ```
 
 Reports are generated for a single state at a time. Use the optional `--month` flag to target a specific month (`YYYY-MM`). The output file name now includes the state and month for clarity.
+
+## Troubleshooting
+
+If you encounter an error like `duckdb.duckdb.IOException: IO Error: Cannot open file` when generating reports, the database file is likely missing. Run `python scripts/init_database.py` to create an empty database or `python scripts/sync_demo.py` to pull data from Airtable.

--- a/scripts/init_database.py
+++ b/scripts/init_database.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Initialize the DuckDB database used by SERFF Analytics."""
+import argparse
+import os
+from serff_analytics.db import DatabaseManager
+from serff_analytics.config import Config
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create the local DuckDB database")
+    parser.add_argument(
+        "--db-path", default=Config.DB_PATH, help="Location of the database file"
+    )
+    args = parser.parse_args()
+
+    if os.path.exists(args.db_path):
+        print(f"Database already exists at {args.db_path}")
+        return
+
+    DatabaseManager(args.db_path)
+    print(f"Database created at {args.db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/serff_analytics/config.py
+++ b/serff_analytics/config.py
@@ -8,4 +8,5 @@ class Config:
     AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
     AIRTABLE_BASE_ID = os.getenv("AIRTABLE_BASE_ID")
     AIRTABLE_TABLE_NAME = os.getenv("AIRTABLE_TABLE_NAME")
-    DB_PATH = "data/insurance_filings.db"
+    # Allow the database path to be overridden via environment variable
+    DB_PATH = os.getenv("DATABASE_PATH", "data/insurance_filings.db")

--- a/tests/newsletter/test_state_newsletter_db.py
+++ b/tests/newsletter/test_state_newsletter_db.py
@@ -1,0 +1,10 @@
+import os
+from serff_analytics.reports.state_newsletter import StateNewsletterReport
+
+
+def test_db_auto_created(tmp_path):
+    db_file = tmp_path / "auto.db"
+    report = StateNewsletterReport(db_path=str(db_file))
+    conn = report._get_connection()
+    assert db_file.exists()
+    conn.close()


### PR DESCRIPTION
## Summary
- read DATABASE_PATH env var in configuration
- automatically create missing database in state newsletter
- add init_database helper script
- document db setup and troubleshooting
- ensure database auto creation is tested

## Testing
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_b_683dbbba60ec832b94ec50c36ccba87a