### PR TITLE
Check data availability for state newsletter reports

### DIFF
--- a/tests/newsletter/test_state_newsletter_nodata.py
+++ b/tests/newsletter/test_state_newsletter_nodata.py
@@ -1,0 +1,11 @@
+import pytest
+from serff_analytics.reports.state_newsletter import StateNewsletterReport, NoDataError
+from serff_analytics.db import DatabaseManager
+
+
+def test_generate_with_no_data(tmp_path):
+    db_file = tmp_path / "empty.db"
+    DatabaseManager(str(db_file))
+    report = StateNewsletterReport(db_path=str(db_file))
+    with pytest.raises(NoDataError):
+        report.generate("TX", "2024-01")


### PR DESCRIPTION
## Summary
- define a `NoDataError` in `state_newsletter`
- detect when no filings exist and raise `NoDataError`
- test newsletter generation without data

## Testing
- `source venv/bin/activate`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_683dbf570464832b8dc5267649d645c2