### PR TITLE
Handle missing state newsletter DB

### DIFF
--- a/serff_analytics/reports/state_newsletter.py
+++ b/serff_analytics/reports/state_newsletter.py
@@ -71,13 +71,19 @@ class StateNewsletterReport:
         return start, end, label
 
     def _get_connection(self):
-        """Return a DuckDB connection, creating the DB if necessary."""
-        if not os.path.exists(self.db_path):
-            logger.warning("Database file %s not found. Initializing new database.", self.db_path)
-            from serff_analytics.db import DatabaseManager
+        """Return a DuckDB connection.
 
-            # This will create the DB and schema
-            DatabaseManager(self.db_path)
+        Raises
+        ------
+        FileNotFoundError
+            If the configured database file does not exist.
+        """
+        if not os.path.exists(self.db_path):
+            logger.error(
+                "Database file %s not found. Run 'python scripts/sync_demo.py' to initialize it.",
+                self.db_path,
+            )
+            raise FileNotFoundError(f"Database file {self.db_path} not found")
         try:
             return duckdb.connect(self.db_path)
         except Exception as exc:

--- a/tests/newsletter/test_state_newsletter_db.py
+++ b/tests/newsletter/test_state_newsletter_db.py
@@ -1,10 +1,10 @@
 import os
+import pytest
 from serff_analytics.reports.state_newsletter import StateNewsletterReport
 
 
-def test_db_auto_created(tmp_path):
-    db_file = tmp_path / "auto.db"
+def test_missing_db_raises(tmp_path):
+    db_file = tmp_path / "missing.db"
     report = StateNewsletterReport(db_path=str(db_file))
-    conn = report._get_connection()
-    assert db_file.exists()
-    conn.close()
+    with pytest.raises(FileNotFoundError):
+        report._get_connection()


### PR DESCRIPTION
## Summary
- prevent automatic creation of the state newsletter database
- raise `FileNotFoundError` with instructions when DB is absent
- update tests to expect the new error behaviour

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_683dbf4be514832b95625084cee2b657