### PR TITLE
Enable Github push and Airtable log in state newsletter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -176,13 +176,15 @@ This project now includes a monthly HTML newsletter template for any U.S. state.
 ### Generating a Report
 
 ```bash
-python -m serff_analytics.reports.state_newsletter Illinois --month 2024-03 > reports/illinois_march_2024.html
+python -m serff_analytics.reports.state_newsletter Illinois --month 2024-03
 ```
 
-To see all database queries executed, add the `--test` flag:
+The report is saved to `docs/reports/2024-mar/illinois.html`, committed to GitHub, and logged in Airtable.
+
+To generate without pushing or logging, add the `--test` flag:
 
 ```bash
-python -m serff_analytics.reports.state_newsletter Illinois --month 2024-03 --test > reports/illinois_march_2024.html
+python -m serff_analytics.reports.state_newsletter Illinois --month 2024-03 --test
 ```
 
 ### Newsletter Workflow Commands


### PR DESCRIPTION
## Summary
- allow specifying output directory for newsletter reports
- default `state_newsletter.py` to push generated reports to GitHub
- log new reports to Airtable when not in test mode
- document new behavior in docs

## Testing
- `python format_code.py`
- `python scripts/run_tests.py` *(fails: ModuleNotFoundError: dotenv, requests, postmarker, duckdb, jinja2)*

------
https://chatgpt.com/codex/tasks/task_b_683f5e35002c832bbd2ee078cce6b26f