### PR TITLE
Link reports to filings

### DIFF
--- a/src/generate_reports.py
+++ b/src/generate_reports.py
@@ -77,7 +77,13 @@ def generate_all_reports(dry_run: bool = False) -> None:
                     f"{year}-{month.lower()[:3]}/{filename}"
                 )
 
-                manager.log_report(state=state, month=month, year=year, report_url=report_url)
+                manager.log_report(
+                    state=state,
+                    month=month,
+                    year=year,
+                    report_url=report_url,
+                    filings=reporter.last_filing_ids,
+                )
 
                 print(" ✓")
                 generated_count += 1

--- a/src/report_manager.py
+++ b/src/report_manager.py
@@ -18,7 +18,7 @@ class ReportManager:
             'Reports'
         )
     
-    def log_report(self, state, month, year, report_url, name=None):
+    def log_report(self, state, month, year, report_url, name=None, filings=None):
         """
         Create a new report entry in Airtable
         
@@ -28,6 +28,7 @@ class ReportManager:
             year: Year (e.g., "2024")
             report_url: GitHub Pages URL for the report
             name: Optional name/title for the report
+            filings: Optional list of filing record IDs to link
             
         Returns:
             The created Airtable record
@@ -36,14 +37,18 @@ class ReportManager:
         if not name:
             name = f"{state} {month} {year}"
         
-        record = self.table.create({
+        record_data = {
             'Name': name,
             'State': state,
             'Month': month,
             'Year': year,
             'Report URL': report_url,
             'Status': 'Generated'
-        })
+        }
+        if filings:
+            record_data['Filings'] = filings
+
+        record = self.table.create(record_data)
         
         print(f"✓ Logged {state} {month} {year} report to Airtable")
         return record


### PR DESCRIPTION
## Summary
- wire up `StateNewsletterReport` to expose the highest-impact filing IDs
- allow `ReportManager.log_report` to accept filing IDs
- store linked filings when generating newsletters

## Testing
- `python scripts/run_tests.py` *(fails: ConnectionRefusedError & ImportError)*

------
https://chatgpt.com/codex/tasks/task_b_684060a97968832b89c9f8ebbbc45a6c