### PR TITLE
Fix missing imports in report generation scripts

### DIFF
--- a/src/generate_reports.py
+++ b/src/generate_reports.py
@@ -5,9 +5,15 @@ import os
 import subprocess
 import sys
 from datetime import datetime
+from pathlib import Path
 from dotenv import load_dotenv
 
 from src.report_manager import ReportManager
+from src.shared.utils import ALL_STATES, get_current_month_year
+from serff_analytics.reports.state_newsletter import (
+    StateNewsletterReport,
+    normalize_state_abbr,
+)
 from serff_analytics.db.utils import get_month_boundaries
 from serff_analytics.db import DatabaseManager
 from serff_analytics.config import Config

--- a/src/send_reports.py
+++ b/src/send_reports.py
@@ -1,5 +1,7 @@
 from dotenv import load_dotenv
 import os
+from pathlib import Path
+from datetime import datetime
 from src.report_manager import ReportManager
 import logging
 from src.email_service import (
@@ -7,6 +9,8 @@ from src.email_service import (
     get_test_subscribers,
     get_subscribers_by_state,
 )
+from src.shared.utils import get_current_month_year
+from serff_analytics.reports.state_newsletter import normalize_state_abbr
 
 load_dotenv()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- update report generation to import Path, helper utils, and newsletter report class
- fix send reports script imports for newsletter utils

## Testing
- `python scripts/run_tests.py` *(fails: ModuleNotFoundError: dotenv, requests, duckdb, jinja2)*

------
https://chatgpt.com/codex/tasks/task_b_68407155af1c832b8d3c94d5283c4e57