### PR TITLE
Improve Airtable number parser

### DIFF
--- a/serff_analytics/ingest/airtable_sync.py
+++ b/serff_analytics/ingest/airtable_sync.py
@@ -134,9 +134,24 @@ class AirtableSync:
         """Safely parse numeric values"""
         if pd.isna(value) or value == "" or value is None:
             return None
+        if isinstance(value, str):
+            cleaned = value.strip().replace(",", "").replace(" ", "")
+            if "%" in cleaned:
+                cleaned = cleaned.replace("%", "")
+                try:
+                    return float(cleaned) / 100.0
+                except Exception:
+                    logger.warning(f"Failed to parse percentage value '{value}'")
+                    return None
+            try:
+                return float(cleaned)
+            except Exception:
+                logger.warning(f"Failed to parse number '{value}'")
+                return None
         try:
             return float(value)
-        except:
+        except Exception:
+            logger.warning(f"Failed to parse number '{value}'")
             return None
 
     def _parse_date(self, value):

--- a/tests/ingest/test_parse_number.py
+++ b/tests/ingest/test_parse_number.py
@@ -1,0 +1,10 @@
+import pytest
+from serff_analytics.ingest.airtable_sync import AirtableSync
+
+sync = AirtableSync.__new__(AirtableSync)
+
+def test_percentage_string_parses_correctly():
+    assert sync._parse_number("7.00%") == pytest.approx(0.07)
+
+def test_regular_numeric_string():
+    assert sync._parse_number("1234") == 1234.0


### PR DESCRIPTION
## Summary
- handle percent strings in `AirtableSync._parse_number`
- add regression tests for parsing percentages and regular numbers

## Testing
- `python scripts/run_tests.py` *(fails: ImportError and network errors)*

------
https://chatgpt.com/codex/tasks/task_b_684093b12a0c832bbff53ed1385a28ad