### PR TITLE
Revert parse_number function

### DIFF
--- a/serff_analytics/ingest/airtable_sync.py
+++ b/serff_analytics/ingest/airtable_sync.py
@@ -134,20 +134,6 @@ class AirtableSync:
         """Safely parse numeric values"""
         if pd.isna(value) or value == "" or value is None:
             return None
-        if isinstance(value, str):
-            cleaned = value.strip().replace(",", "").replace(" ", "")
-            if "%" in cleaned:
-                cleaned = cleaned.replace("%", "")
-                try:
-                    return float(cleaned) / 100.0
-                except Exception:
-                    logger.warning(f"Failed to parse percentage value '{value}'")
-                    return None
-            try:
-                return float(cleaned)
-            except Exception:
-                logger.warning(f"Failed to parse number '{value}'")
-                return None
         try:
             return float(value)
         except Exception:

--- a/tests/ingest/test_parse_number.py
+++ b/tests/ingest/test_parse_number.py
@@ -1,10 +1,9 @@
-import pytest
 from serff_analytics.ingest.airtable_sync import AirtableSync
 
 sync = AirtableSync.__new__(AirtableSync)
 
-def test_percentage_string_parses_correctly():
-    assert sync._parse_number("7.00%") == pytest.approx(0.07)
+def test_percentage_string_returns_none():
+    assert sync._parse_number("7.00%") is None
 
 def test_regular_numeric_string():
     assert sync._parse_number("1234") == 1234.0


### PR DESCRIPTION
## Summary
- revert parse_number to its simple float conversion
- update unit test for parse_number

## Testing
- `python format_code.py`
- `python scripts/run_tests.py` *(fails: ImportError and network errors)*

------
https://chatgpt.com/codex/tasks/task_b_6840986d3b74832b88454dfc686174d1