### PR TITLE
Update precision migration for premium change

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -282,6 +282,12 @@ Reports are automatically available when pushed to the `/docs` folder.
 ### Database Issues
 If you encounter an error like `duckdb.duckdb.IOException: IO Error: Cannot open file` when generating reports, the database file is likely missing. Run `python scripts/sync_demo.py` to create the database and pull data from Airtable.
 
+Older installations may store `Premium_Change_Number` with only two decimal places. The current schema uses four decimal places. Any script that initializes `DatabaseManager` will automatically apply the following migration:
+
+```sql
+ALTER TABLE filings ALTER COLUMN Premium_Change_Number SET DATA TYPE DECIMAL(10,4);
+```
+
 ### Email Issues
 - Check Postmark dashboard for delivery status
 - Verify sender domain is authenticated


### PR DESCRIPTION
## Summary
- adjust `init_database` to migrate Premium_Change_Number precision automatically
- document the migration step in `docs/README.md`

## Testing
- `python format_code.py`
- `python scripts/run_tests.py` *(fails: ConnectionError during tests)*

------
https://chatgpt.com/codex/tasks/task_b_68419975a00c832b871256732a0fe615