### PR TITLE
Optimize bulk insert in Airtable sync

### DIFF
--- a/serff_analytics/ingest/airtable_sync.py
+++ b/serff_analytics/ingest/airtable_sync.py
@@ -21,7 +21,7 @@ class AirtableSync:
         """Sync data from Airtable to DuckDB"""
         try:
             logger.info("Starting Airtable sync...")
-            
+
             # Optional: Run diagnostics first
             # self.diagnose_rate_change_field()
             # self.debug_field_values("Overall Rate Change Number")
@@ -33,24 +33,28 @@ class AirtableSync:
             # Convert to DataFrame
             data = []
             parsing_errors = []
-            
+
             for record in records:
                 fields = record["fields"]
                 # Map YOUR ACTUAL Airtable fields to database columns
                 product_line = fields.get("Product Line", "")
-                
+
                 # Track parsing issues for Premium_Change_Number
                 rate_change_raw = fields.get("Overall Rate Change Number")
-                rate_change_parsed = self._parse_number(rate_change_raw, "Overall Rate Change Number")
-                
+                rate_change_parsed = self._parse_number(
+                    rate_change_raw, "Overall Rate Change Number"
+                )
+
                 if rate_change_raw is not None and rate_change_parsed is None:
-                    parsing_errors.append({
-                        'record_id': record["id"],
-                        'field': 'Overall Rate Change Number',
-                        'raw_value': rate_change_raw,
-                        'value_type': type(rate_change_raw).__name__
-                    })
-                
+                    parsing_errors.append(
+                        {
+                            "record_id": record["id"],
+                            "field": "Overall Rate Change Number",
+                            "raw_value": rate_change_raw,
+                            "value_type": type(rate_change_raw).__name__,
+                        }
+                    )
+
                 row = {
                     "Record_ID": record["id"],
                     "Company": fields.get("Parent Company", ""),
@@ -70,22 +74,16 @@ class AirtableSync:
                         fields.get("Previous Increase Date")
                     ),
                     "Previous_Increase_Percentage": self._parse_number(
-                        fields.get("Previous Increase Percentage"),
-                        "Previous Increase Percentage"
+                        fields.get("Previous Increase Percentage"), "Previous Increase Percentage"
                     ),
                     "Policyholders_Affected_Number": self._parse_number(
-                        fields.get("Policyholders Affected Number"),
-                        "Policyholders Affected Number"
+                        fields.get("Policyholders Affected Number"), "Policyholders Affected Number"
                     ),
                     "Policyholders_Affected_Text": fields.get("Policyholders Affected Text", ""),
                     "Total_Written_Premium_Number": self._parse_number(
-                        fields.get("Total Written Premium Number"),
-                        "Total Written Premium Number"
+                        fields.get("Total Written Premium Number"), "Total Written Premium Number"
                     ),
-                    "Impact_Score": self._parse_number(
-                        fields.get("Impact Score"),
-                        "Impact Score"
-                    ),
+                    "Impact_Score": self._parse_number(fields.get("Impact Score"), "Impact Score"),
                     "Total_Written_Premium_Text": fields.get("Total Written Premium Text", ""),
                     "SERFF_Tracking_Number": fields.get("SERFF Tracking Number", ""),
                     "Specific_Coverages": fields.get("Specific Coverages", ""),
@@ -104,7 +102,9 @@ class AirtableSync:
             if parsing_errors:
                 logger.warning(f"Found {len(parsing_errors)} records with parsing errors:")
                 for error in parsing_errors[:5]:  # Show first 5
-                    logger.warning(f"  Record {error['record_id']}: {error['field']} = {repr(error['raw_value'])} ({error['value_type']})")
+                    logger.warning(
+                        f"  Record {error['record_id']}: {error['field']} = {repr(error['raw_value'])} ({error['value_type']})"
+                    )
                 if len(parsing_errors) > 5:
                     logger.warning(f"  ... and {len(parsing_errors) - 5} more")
 
@@ -127,27 +127,19 @@ class AirtableSync:
             # Clear existing data (for initial testing)
             conn.execute("DELETE FROM filings")
 
-            # Insert new data with explicit columns
+            # Insert new data in bulk using a staging relation
             columns_str = ", ".join(df_columns)
-            placeholders = ", ".join(["?" for _ in df_columns])
-            insert_query = f"INSERT INTO filings ({columns_str}) VALUES ({placeholders})"
-
-            # Insert row by row (slower but more reliable for debugging)
-            inserted = 0
-            failed_inserts = []
-            
-            for idx, row in df_filtered.iterrows():
-                try:
-                    values = [row[col] for col in df_columns]
-                    conn.execute(insert_query, values)
-                    inserted += 1
-                    if inserted % 500 == 0:
-                        logger.info(f"Inserted {inserted} records...")
-                except Exception as e:
-                    logger.error(f"Failed to insert row {idx}: {e}")
-                    logger.error(f"Row data: {row.to_dict()}")
-                    failed_inserts.append({'index': idx, 'error': str(e), 'record_id': row.get('Record_ID', 'Unknown')})
-                    # Continue with other rows
+            conn.register("staging", df_filtered[df_columns])
+            try:
+                insert_query = (
+                    f"INSERT INTO filings ({columns_str}) " f"SELECT {columns_str} FROM staging"
+                )
+                conn.execute(insert_query)
+                inserted = conn.execute("SELECT COUNT(*) FROM staging").fetchone()[0]
+                failed_inserts = 0
+                logger.info(f"Inserted {inserted} records...")
+            finally:
+                conn.unregister("staging")
 
             # Get count
             total_records = conn.execute("SELECT COUNT(*) FROM filings").fetchone()[0]
@@ -155,25 +147,28 @@ class AirtableSync:
             conn.close()
 
             logger.info(f"Sync completed. Total records in database: {total_records}")
-            
+
             # Summary report
             result = {
-                "success": True, 
-                "records_processed": len(df), 
+                "success": True,
+                "records_processed": len(df),
                 "records_inserted": inserted,
                 "total_records": total_records,
                 "parsing_errors": len(parsing_errors),
-                "failed_inserts": len(failed_inserts)
+                "failed_inserts": failed_inserts,
             }
-            
+
             if parsing_errors or failed_inserts:
-                result["warning"] = f"{len(parsing_errors)} parsing errors, {len(failed_inserts)} insert failures"
-            
+                result["warning"] = (
+                    f"{len(parsing_errors)} parsing errors, {failed_inserts} insert failures"
+                )
+
             return result
 
         except Exception as e:
             logger.error(f"Sync failed: {type(e).__name__}: {e}")
             import traceback
+
             logger.error(traceback.format_exc())
             return {"success": False, "error": str(e)}
 
@@ -181,22 +176,22 @@ class AirtableSync:
         """Safely parse numeric values, including percentages stored as decimals"""
         if pd.isna(value) or value == "" or value is None:
             return None
-        
+
         try:
             # If it's already a number (int or float), return it
             if isinstance(value, (int, float)):
                 # For percentage fields stored as decimals (0.179 = 17.9%)
                 # Airtable already provides them in the correct decimal format
                 return float(value)
-            
+
             # If it's a string, try to convert
             if isinstance(value, str):
                 # Remove any whitespace
                 value = value.strip()
-                
+
                 # Try direct conversion
                 return float(value)
-                
+
         except (ValueError, TypeError) as e:
             logger.warning(f"Failed to parse number '{value}' from field '{field_name}': {e}")
             logger.debug(f"Value type: {type(value)}, Value repr: {repr(value)}")
@@ -217,57 +212,63 @@ class AirtableSync:
     def diagnose_rate_change_field(self, sample_size=10):
         """Diagnose issues with the Overall Rate Change Number field"""
         logger.info("=== Diagnosing Overall Rate Change Number field ===")
-        
+
         records = self.table.all()[:sample_size]
-        
+
         issues = []
         valid_count = 0
-        
+
         for i, record in enumerate(records):
             value = record["fields"].get("Overall Rate Change Number")
             parsed = self._parse_number(value, "Overall Rate Change Number")
-            
+
             if parsed is not None:
                 valid_count += 1
                 logger.info(f"Record {i+1}: {value} -> {parsed} ✓")
             else:
-                issues.append({
-                    'record_id': record['id'],
-                    'raw_value': value,
-                    'value_type': type(value).__name__
-                })
-                logger.warning(f"Record {i+1}: {repr(value)} (type: {type(value).__name__}) -> None ✗")
-        
+                issues.append(
+                    {
+                        "record_id": record["id"],
+                        "raw_value": value,
+                        "value_type": type(value).__name__,
+                    }
+                )
+                logger.warning(
+                    f"Record {i+1}: {repr(value)} (type: {type(value).__name__}) -> None ✗"
+                )
+
         logger.info(f"\nSummary: {valid_count}/{sample_size} records parsed successfully")
-        
+
         if issues:
             logger.warning(f"Found {len(issues)} problematic records")
             for issue in issues[:5]:  # Show first 5 issues
-                logger.warning(f"  Record {issue['record_id']}: {repr(issue['raw_value'])} ({issue['value_type']})")
-        
+                logger.warning(
+                    f"  Record {issue['record_id']}: {repr(issue['raw_value'])} ({issue['value_type']})"
+                )
+
         return valid_count, issues
 
     def debug_field_values(self, field_name="Overall Rate Change Number", limit=20):
         """Debug specific field values from Airtable"""
         records = self.table.all()[:limit]
-        
+
         value_types = {}
         examples_by_type = {}
-        
+
         for record in records:
             value = record["fields"].get(field_name)
             value_type = type(value).__name__
             value_repr = repr(value)
-            
+
             # Count types
             value_types[value_type] = value_types.get(value_type, 0) + 1
-            
+
             # Collect examples
             if value_type not in examples_by_type:
                 examples_by_type[value_type] = []
             if len(examples_by_type[value_type]) < 3:  # Keep first 3 examples
                 examples_by_type[value_type].append(value_repr)
-        
+
         logger.info(f"\n=== Field '{field_name}' Analysis ===")
         logger.info(f"Value type distribution:")
         for vtype, count in value_types.items():
@@ -278,9 +279,9 @@ class AirtableSync:
     def _inspect_percentage_field(self, records_sample=5):
         """Inspect how Airtable returns percentage fields"""
         logger.info("Inspecting percentage field format from Airtable...")
-        
+
         records = self.table.all()[:records_sample]  # Get first few records
-        
+
         for i, record in enumerate(records):
             value = record["fields"].get("Overall Rate Change Number")
             logger.info(f"Record {i+1}:")
@@ -295,68 +296,70 @@ class AirtableSync:
             "Previous Increase Percentage",
             "Policyholders Affected Number",
             "Total Written Premium Number",
-            "Impact Score"
+            "Impact Score",
         ]
-        
+
         logger.info("=== Validating All Numeric Fields ===")
         records = self.table.all()
-        
+
         field_stats = {}
-        
+
         for field in numeric_fields:
             valid = 0
             invalid = 0
             invalid_examples = []
-            
+
             for record in records:
                 value = record["fields"].get(field)
                 parsed = self._parse_number(value, field)
-                
+
                 if value is not None:  # Only count non-null values
                     if parsed is not None:
                         valid += 1
                     else:
                         invalid += 1
                         if len(invalid_examples) < 3:  # Keep first 3 examples
-                            invalid_examples.append({
-                                'record_id': record['id'],
-                                'value': repr(value),
-                                'type': type(value).__name__
-                            })
-            
+                            invalid_examples.append(
+                                {
+                                    "record_id": record["id"],
+                                    "value": repr(value),
+                                    "type": type(value).__name__,
+                                }
+                            )
+
             field_stats[field] = {
-                'valid': valid,
-                'invalid': invalid,
-                'invalid_examples': invalid_examples
+                "valid": valid,
+                "invalid": invalid,
+                "invalid_examples": invalid_examples,
             }
-        
+
         # Report results
         logger.info("\nValidation Results:")
         for field, stats in field_stats.items():
             logger.info(f"\n{field}:")
             logger.info(f"  Valid: {stats['valid']}")
             logger.info(f"  Invalid: {stats['invalid']}")
-            if stats['invalid_examples']:
+            if stats["invalid_examples"]:
                 logger.info("  Invalid examples:")
-                for ex in stats['invalid_examples']:
+                for ex in stats["invalid_examples"]:
                     logger.info(f"    Record {ex['record_id']}: {ex['value']} ({ex['type']})")
-        
+
         return field_stats
 
 
 # Example usage:
 if __name__ == "__main__":
     sync = AirtableSync()
-    
+
     # Run diagnostics first
     sync.diagnose_rate_change_field()
-    
+
     # Or debug field values
     sync.debug_field_values("Overall Rate Change Number")
-    
+
     # Or validate all numeric fields
     sync.validate_numeric_fields()
-    
+
     # Then run the sync
     result = sync.sync_data()
     print(f"Sync result: {result}")


### PR DESCRIPTION
## Summary
- register the filtered DataFrame as `staging` inside `AirtableSync.sync_data`
- execute a single insert from `staging` instead of row-by-row
- keep logging of inserted row count

## Testing
- `python format_code.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6841b5f17ca8832b8419d01a7cd9d544