### PR TITLE
Implement retries for Airtable API calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ typing_extensions==4.13.2
 tzdata==2025.2
 urllib3==2.4.0
 flask==3.1.1
+tenacity==8.2.3


### PR DESCRIPTION
## Summary
- add `tenacity` dependency
- wrap Airtable API calls in `_safe_call` with retry logic
- use `_safe_call` in data fetch and diagnostic functions

## Testing
- `python format_code.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6841b98ab610832ba6266ded7e528d36