### PR TITLE
Add context manager helpers to DatabaseManager

### DIFF
--- a/serff_analytics/db/__init__.py
+++ b/serff_analytics/db/__init__.py
@@ -3,6 +3,7 @@ import pandas as pd
 from datetime import datetime
 import logging
 import os
+from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -17,65 +18,87 @@ class DatabaseManager:
     def get_connection(self):
         return duckdb.connect(self.db_path)
 
+    @contextmanager
+    def connection(self):
+        """Context manager that yields a DuckDB connection and closes it."""
+        conn = self.get_connection()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @contextmanager
+    def transaction(self):
+        """Context manager for a database transaction."""
+        with self.connection() as conn:
+            try:
+                conn.begin()
+                yield conn
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
     def init_database(self):
         """Initialize database with proper schema"""
-        conn = self.get_connection()
+        with self.connection() as conn:
 
-        # Check existing schema for column precision
-        try:
-            info = conn.execute("PRAGMA table_info('filings')").fetchall()
-            for row in info:
-                if row[1] == "Premium_Change_Number" and row[2].upper() == "DECIMAL(10,2)":
-                    # Drop dependent indexes before altering the column type
-                    conn.execute("DROP INDEX IF EXISTS idx_state_product")
-                    conn.execute("DROP INDEX IF EXISTS idx_company")
-                    conn.execute("DROP INDEX IF EXISTS idx_effective_date")
-                    conn.execute(
-                        "ALTER TABLE filings ALTER COLUMN Premium_Change_Number SET DATA TYPE DECIMAL(10,4)"
-                    )
-                    logger.info("Migrated Premium_Change_Number to DECIMAL(10,4)")
-                    break
-        except duckdb.CatalogException:
-            # Table doesn't exist yet; it will be created below
-            pass
+            # Check existing schema for column precision
+            try:
+                info = conn.execute("PRAGMA table_info('filings')").fetchall()
+                for row in info:
+                    if row[1] == "Premium_Change_Number" and row[2].upper() == "DECIMAL(10,2)":
+                        # Drop dependent indexes before altering the column type
+                        conn.execute("DROP INDEX IF EXISTS idx_state_product")
+                        conn.execute("DROP INDEX IF EXISTS idx_company")
+                        conn.execute("DROP INDEX IF EXISTS idx_effective_date")
+                        conn.execute(
+                            "ALTER TABLE filings ALTER COLUMN Premium_Change_Number SET DATA TYPE DECIMAL(10,4)"
+                        )
+                        logger.info("Migrated Premium_Change_Number to DECIMAL(10,4)")
+                        break
+            except duckdb.CatalogException:
+                # Table doesn't exist yet; it will be created below
+                pass
 
-        # Create main table matching your Airtable fields
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS filings (
-                Record_ID VARCHAR PRIMARY KEY,
-                Company VARCHAR,
-                Subsidiary VARCHAR,
-                State VARCHAR,
-                Product_Line VARCHAR,
-                Rate_Change_Type VARCHAR,
-                Premium_Change_Number DECIMAL(10,4),
-                Premium_Change_Amount_Text VARCHAR,
-                Effective_Date DATE,
-                Previous_Increase_Date DATE,
-                Previous_Increase_Percentage DECIMAL(10,4),
-                Policyholders_Affected_Number INTEGER,
-                Policyholders_Affected_Text VARCHAR,
-                Total_Written_Premium_Number DECIMAL(15,2),
-                Total_Written_Premium_Text VARCHAR,
-                SERFF_Tracking_Number VARCHAR,
-                Specific_Coverages VARCHAR,
-                Stated_Reasons VARCHAR,
-                Population VARCHAR,
-                Impact_Score DECIMAL(10,2),
-                Renewals_Date DATE,
-                Created_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                Updated_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            # Create main table matching your Airtable fields
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS filings (
+                    Record_ID VARCHAR PRIMARY KEY,
+                    Company VARCHAR,
+                    Subsidiary VARCHAR,
+                    State VARCHAR,
+                    Product_Line VARCHAR,
+                    Rate_Change_Type VARCHAR,
+                    Premium_Change_Number DECIMAL(10,4),
+                    Premium_Change_Amount_Text VARCHAR,
+                    Effective_Date DATE,
+                    Previous_Increase_Date DATE,
+                    Previous_Increase_Percentage DECIMAL(10,4),
+                    Policyholders_Affected_Number INTEGER,
+                    Policyholders_Affected_Text VARCHAR,
+                    Total_Written_Premium_Number DECIMAL(15,2),
+                    Total_Written_Premium_Text VARCHAR,
+                    SERFF_Tracking_Number VARCHAR,
+                    Specific_Coverages VARCHAR,
+                    Stated_Reasons VARCHAR,
+                    Population VARCHAR,
+                    Impact_Score DECIMAL(10,2),
+                    Renewals_Date DATE,
+                    Created_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    Updated_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
             )
-        """
-        )
 
-        # Create indexes for performance
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_state_product ON filings(State, Product_Line)")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_company ON filings(Company, Subsidiary)")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_effective_date ON filings(Effective_Date)")
+            # Create indexes for performance
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_state_product ON filings(State, Product_Line)"
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_company ON filings(Company, Subsidiary)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_effective_date ON filings(Effective_Date)")
 
-        conn.close()
         logger.info("Database initialized successfully")
 
     def get_schema_context(self):


### PR DESCRIPTION
## Summary
- add `connection` and `transaction` context manager utilities
- use the new context manager inside `init_database`

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6841bbfd4140832ba12065fb340021ce