### PR TITLE
Add execute helper to DatabaseManager

### DIFF
--- a/serff_analytics/db/__init__.py
+++ b/serff_analytics/db/__init__.py
@@ -1,9 +1,17 @@
+"""DuckDB utility helpers.
+
+This module exposes :class:`DatabaseManager` for interacting with the local
+analytics database.  A convenience :py:meth:`DatabaseManager.execute` helper is
+provided to run a SQL statement using a short‑lived connection.
+"""
+
 import duckdb
 import pandas as pd
 from datetime import datetime
 import logging
 import os
 from contextlib import contextmanager
+from typing import Iterable, Any
 
 logger = logging.getLogger(__name__)
 
@@ -39,71 +47,65 @@ class DatabaseManager:
                 conn.rollback()
                 raise
 
+    def execute(self, query: str, params: Iterable[Any] | None = None):
+        """Run a SQL statement using a short-lived connection."""
+        with self.connection() as conn:
+            return conn.execute(query, params or [])
+
     def init_database(self):
         """Initialize database with proper schema"""
-<<<<<<< HEAD
-        conn = self.get_connection()
+        try:
+            info = self.execute("PRAGMA table_info('filings')").fetchall()
+            for row in info:
+                if row[1] == "Premium_Change_Number" and row[2].upper() == "DECIMAL(10,2)":
+                    # Drop dependent indexes before altering the column type
+                    self.execute("DROP INDEX IF EXISTS idx_state_product")
+                    self.execute("DROP INDEX IF EXISTS idx_company")
+                    self.execute("DROP INDEX IF EXISTS idx_effective_date")
+                    self.execute(
+                        "ALTER TABLE filings ALTER COLUMN Premium_Change_Number SET DATA TYPE DECIMAL(10,4)"
+                    )
+                    logger.info("Migrated Premium_Change_Number to DECIMAL(10,4)")
+                    break
+        except duckdb.CatalogException:
             # Table doesn't exist yet; it will be created below
-        pass
-=======
-        with self.connection() as conn:
+            pass
 
-            # Check existing schema for column precision
-            try:
-                info = conn.execute("PRAGMA table_info('filings')").fetchall()
-                for row in info:
-                    if row[1] == "Premium_Change_Number" and row[2].upper() == "DECIMAL(10,2)":
-                        # Drop dependent indexes before altering the column type
-                        conn.execute("DROP INDEX IF EXISTS idx_state_product")
-                        conn.execute("DROP INDEX IF EXISTS idx_company")
-                        conn.execute("DROP INDEX IF EXISTS idx_effective_date")
-                        conn.execute(
-                            "ALTER TABLE filings ALTER COLUMN Premium_Change_Number SET DATA TYPE DECIMAL(10,4)"
-                        )
-                        logger.info("Migrated Premium_Change_Number to DECIMAL(10,4)")
-                        break
-            except duckdb.CatalogException:
-                # Table doesn't exist yet; it will be created below
-                pass
->>>>>>> c72ed35c7292196537f6f30cc9dae36b6a886959
-
-            # Create main table matching your Airtable fields
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS filings (
-                    Record_ID VARCHAR PRIMARY KEY,
-                    Company VARCHAR,
-                    Subsidiary VARCHAR,
-                    State VARCHAR,
-                    Product_Line VARCHAR,
-                    Rate_Change_Type VARCHAR,
-                    Premium_Change_Number DECIMAL(10,4),
-                    Premium_Change_Amount_Text VARCHAR,
-                    Effective_Date DATE,
-                    Previous_Increase_Date DATE,
-                    Previous_Increase_Percentage DECIMAL(10,4),
-                    Policyholders_Affected_Number INTEGER,
-                    Policyholders_Affected_Text VARCHAR,
-                    Total_Written_Premium_Number DECIMAL(15,2),
-                    Total_Written_Premium_Text VARCHAR,
-                    SERFF_Tracking_Number VARCHAR,
-                    Specific_Coverages VARCHAR,
-                    Stated_Reasons VARCHAR,
-                    Population VARCHAR,
-                    Impact_Score DECIMAL(10,2),
-                    Renewals_Date DATE,
-                    Created_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    Updated_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                )
-                """
+        # Create main table matching your Airtable fields
+        self.execute(
+            """
+            CREATE TABLE IF NOT EXISTS filings (
+                Record_ID VARCHAR PRIMARY KEY,
+                Company VARCHAR,
+                Subsidiary VARCHAR,
+                State VARCHAR,
+                Product_Line VARCHAR,
+                Rate_Change_Type VARCHAR,
+                Premium_Change_Number DECIMAL(10,4),
+                Premium_Change_Amount_Text VARCHAR,
+                Effective_Date DATE,
+                Previous_Increase_Date DATE,
+                Previous_Increase_Percentage DECIMAL(10,4),
+                Policyholders_Affected_Number INTEGER,
+                Policyholders_Affected_Text VARCHAR,
+                Total_Written_Premium_Number DECIMAL(15,2),
+                Total_Written_Premium_Text VARCHAR,
+                SERFF_Tracking_Number VARCHAR,
+                Specific_Coverages VARCHAR,
+                Stated_Reasons VARCHAR,
+                Population VARCHAR,
+                Impact_Score DECIMAL(10,2),
+                Renewals_Date DATE,
+                Created_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                Updated_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
+            """
+        )
 
-            # Create indexes for performance
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_state_product ON filings(State, Product_Line)"
-            )
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_company ON filings(Company, Subsidiary)")
-            conn.execute("CREATE INDEX IF NOT EXISTS idx_effective_date ON filings(Effective_Date)")
+        # Create indexes for performance
+        self.execute("CREATE INDEX IF NOT EXISTS idx_state_product ON filings(State, Product_Line)")
+        self.execute("CREATE INDEX IF NOT EXISTS idx_company ON filings(Company, Subsidiary)")
+        self.execute("CREATE INDEX IF NOT EXISTS idx_effective_date ON filings(Effective_Date)")
 
         logger.info("Database initialized successfully")
 


### PR DESCRIPTION
## Summary
- add a module docstring describing DatabaseManager and new helper
- implement `execute` method on DatabaseManager
- refactor `init_database` to use the new helper

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6841bd624874832b8b9fec09afaae60a