### PR TITLE
Add Airtable sync and DB transaction tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from serff_analytics.db import DatabaseManager
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """Return path to a temporary database file."""
+    return tmp_path / "test.db"
+
+
+@pytest.fixture
+def db_manager(db_path):
+    """Return a DatabaseManager connected to the temporary database."""
+    return DatabaseManager(str(db_path))

--- a/tests/ingest/test_airtable_sync.py
+++ b/tests/ingest/test_airtable_sync.py
@@ -1,0 +1,46 @@
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from pyairtable import Table
+
+from serff_analytics.ingest.airtable_sync import AirtableSync
+from serff_analytics.db import DatabaseManager
+from serff_analytics import config
+
+
+def make_record(record_id, rate_change):
+    return {
+        "id": record_id,
+        "fields": {
+            "Parent Company": "PCo",
+            "Filing Company": "FCo",
+            "Impacted State": "TX",
+            "Product Line": "Auto",
+            "Rate Change Type": "increase",
+            "Overall Rate Change Number": rate_change,
+        },
+    }
+
+
+def test_sync_only_updated_records(monkeypatch, db_path):
+    since = datetime.datetime(2024, 1, 1, 0, 0, 0)
+    pages = [[make_record("r1", 0.1)], [make_record("r2", 0.2)]]
+
+    mock_iterate = MagicMock(return_value=pages)
+    monkeypatch.setattr(Table, "iterate", mock_iterate)
+    monkeypatch.setattr(config.Config, "DB_PATH", str(db_path))
+
+    sync = AirtableSync()
+    result = sync.sync_data(since=since)
+
+    mock_iterate.assert_called_once()
+    args, kwargs = mock_iterate.call_args
+    assert kwargs["page_size"] == 100
+    assert "filter_by_formula" in kwargs
+    assert since.isoformat() in kwargs["filter_by_formula"]
+
+    assert result["records_inserted"] == 2
+    with sync.db.connection() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM filings").fetchone()[0]
+    assert count == 2

--- a/tests/ingest/test_db_transaction.py
+++ b/tests/ingest/test_db_transaction.py
@@ -1,0 +1,29 @@
+import pytest
+
+from serff_analytics.db import DatabaseManager
+
+
+def test_transaction_commit(db_manager):
+    with db_manager.connection() as conn:
+        conn.execute("CREATE TABLE test (id INTEGER)")
+
+    with db_manager.transaction() as conn:
+        conn.execute("INSERT INTO test VALUES (1)")
+
+    with db_manager.connection() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM test").fetchone()[0]
+    assert count == 1
+
+
+def test_transaction_rollback(db_manager):
+    with db_manager.connection() as conn:
+        conn.execute("CREATE TABLE test (id INTEGER)")
+
+    with pytest.raises(ValueError):
+        with db_manager.transaction() as conn:
+            conn.execute("INSERT INTO test VALUES (1)")
+            raise ValueError("boom")
+
+    with db_manager.connection() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM test").fetchone()[0]
+    assert count == 0


### PR DESCRIPTION
## Summary
- add `db_path` and `db_manager` fixtures for temporary DBs
- test AirtableSync with mocked paginate results
- ensure DatabaseManager.transaction commits/rolls back correctly

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6841c3ab9a28832ba87b256de9a3c48c