### PR TITLE
Fix DuckDB connection error on startup

### DIFF
--- a/serff_analytics/db/__init__.py
+++ b/serff_analytics/db/__init__.py
@@ -55,7 +55,8 @@ class DatabaseManager:
     def init_database(self):
         """Initialize database with proper schema"""
         try:
-            info = self.execute("PRAGMA table_info('filings')").fetchall()
+            with self.connection() as conn:
+                info = conn.execute("PRAGMA table_info('filings')").fetchall()
             for row in info:
                 if row[1] == "Premium_Change_Number" and row[2].upper() == "DECIMAL(10,2)":
                     # Drop dependent indexes before altering the column type


### PR DESCRIPTION
## Summary
- keep the connection open while fetching table info during DB initialization

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6841c726b5a4832b951b00f15b813d8e