### PR TITLE
Fix previous increase percentage parsing

### DIFF
--- a/serff_analytics/db/__init__.py
+++ b/serff_analytics/db/__init__.py
@@ -73,7 +73,14 @@ class DatabaseManager:
                             "ALTER TABLE filings ALTER COLUMN Premium_Change_Number SET DATA TYPE DECIMAL(10,4)"
                         )
                         logger.info("Migrated Premium_Change_Number to DECIMAL(10,4)")
-                        break
+                    if row[1] == "Previous_Increase_Percentage" and not row[2].upper().startswith(
+                        "VARCHAR"
+                    ):
+                        self._drop_all_indexes(conn)
+                        conn.execute(
+                            "ALTER TABLE filings ALTER COLUMN Previous_Increase_Percentage SET DATA TYPE VARCHAR"
+                        )
+                        logger.info("Migrated Previous_Increase_Percentage to VARCHAR")
         except duckdb.CatalogException:
             # Table doesn't exist yet; it will be created below
             pass
@@ -92,7 +99,7 @@ class DatabaseManager:
                 Premium_Change_Amount_Text VARCHAR,
                 Effective_Date DATE,
                 Previous_Increase_Date DATE,
-                Previous_Increase_Percentage DECIMAL(10,4),
+                Previous_Increase_Percentage VARCHAR,
                 Policyholders_Affected_Number INTEGER,
                 Policyholders_Affected_Text VARCHAR,
                 Total_Written_Premium_Number DECIMAL(15,2),

--- a/serff_analytics/ingest/airtable_sync.py
+++ b/serff_analytics/ingest/airtable_sync.py
@@ -107,9 +107,10 @@ class AirtableSync:
                     "Previous_Increase_Date": self._parse_date(
                         fields.get("Previous Increase Date")
                     ),
-                    "Previous_Increase_Percentage": self._parse_number(
-                        fields.get("Previous Increase Percentage"), "Previous Increase Percentage"
-                    ),
+                    # Store the value exactly as provided. Some records include
+                    # a trailing '%' which caused parse errors when treated as
+                    # numeric.
+                    "Previous_Increase_Percentage": fields.get("Previous Increase Percentage", ""),
                     "Policyholders_Affected_Number": self._parse_number(
                         fields.get("Policyholders Affected Number"), "Policyholders Affected Number"
                     ),
@@ -154,7 +155,10 @@ class AirtableSync:
 
                 # Only keep DataFrame columns that exist in the database
                 df_columns = [col for col in df.columns if col in db_columns]
-                df_filtered = df[df_columns]
+                # Reset the index to ensure a clean RangeIndex before passing
+                # the DataFrame to DuckDB. A non-default index can trigger
+                # IndexError during registration.
+                df_filtered = df[df_columns].reset_index(drop=True)
                 logger.info(f"Filtered DataFrame to columns: {df_columns}")
 
                 # Clear existing data (for initial testing)

--- a/tests/db/test_migration_extra_indexes.py
+++ b/tests/db/test_migration_extra_indexes.py
@@ -13,7 +13,7 @@ CREATE TABLE filings (
     Premium_Change_Amount_Text VARCHAR,
     Effective_Date DATE,
     Previous_Increase_Date DATE,
-    Previous_Increase_Percentage DECIMAL(10,2),
+    Previous_Increase_Percentage VARCHAR,
     Policyholders_Affected_Number INTEGER,
     Policyholders_Affected_Text VARCHAR,
     Total_Written_Premium_Number DECIMAL(15,2),
@@ -48,6 +48,7 @@ def test_migration_drops_extra_indexes(tmp_path):
             for row in conn.execute("PRAGMA table_info('filings')").fetchall()
         }
         assert info["Premium_Change_Number"].upper() == "DECIMAL(10,4)"
+        assert info["Previous_Increase_Percentage"].upper().startswith("VARCHAR")
         indexes = {
             row[0]
             for row in conn.execute(


### PR DESCRIPTION
## Summary
- don't parse Previous Increase Percentage as a number
- keep DataFrame indexes clean when loading to DuckDB
- migrate DB column to VARCHAR and update tests

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6841cc4eb9cc832bb084b4d6a2cb2b04