### PR TITLE
Switch to numeric previous increase field

### DIFF
--- a/serff_analytics/health/data_health_check.py
+++ b/serff_analytics/health/data_health_check.py
@@ -238,7 +238,7 @@ class SimpleDataHealthCheck:
                 Premium_Change_Amount_Text,
                 Effective_Date,
                 Previous_Increase_Date,
-                Previous_Increase_Percentage,
+                Previous_Increase_Number,
                 Policyholders_Affected_Number,
                 Policyholders_Affected_Text,
                 Total_Written_Premium_Number,
@@ -256,7 +256,7 @@ class SimpleDataHealthCheck:
             GROUP BY
                 Company, Subsidiary, State, Product_Line, Rate_Change_Type,
                 Premium_Change_Number, Premium_Change_Amount_Text, Effective_Date,
-                Previous_Increase_Date, Previous_Increase_Percentage,
+                Previous_Increase_Date, Previous_Increase_Number,
                 Policyholders_Affected_Number, Policyholders_Affected_Text,
                 Total_Written_Premium_Number, Total_Written_Premium_Text,
                 SERFF_Tracking_Number, Specific_Coverages, Stated_Reasons,

--- a/serff_analytics/ingest/airtable_sync.py
+++ b/serff_analytics/ingest/airtable_sync.py
@@ -125,7 +125,9 @@ class AirtableSync:
                     or fields.get("Effective Date Requested (New)")
                 ),
                 "Previous_Increase_Date": self._parse_date(fields.get("Previous Increase Date")),
-                "Previous_Increase_Percentage": fields.get("Previous Increase Percentage", ""),
+                "Previous_Increase_Number": self._parse_number(
+                    fields.get("Previous Increase Number"), "Previous Increase Number"
+                ),
                 "Policyholders_Affected_Number": self._parse_number(
                     fields.get("Policyholders Affected Number"), "Policyholders Affected Number"
                 ),
@@ -325,7 +327,7 @@ class AirtableSync:
         """Validate all numeric fields in the dataset"""
         numeric_fields = [
             "Overall Rate Change Number",
-            "Previous Increase Percentage",
+            "Previous Increase Number",
             "Policyholders Affected Number",
             "Total Written Premium Number",
             "Impact Score",

--- a/serff_analytics/reports/agent_report.py
+++ b/serff_analytics/reports/agent_report.py
@@ -456,7 +456,7 @@ class AgentIntelligenceReport:
                 SUM(Policyholders_Affected_Number) as policies_affected,
                 AVG(Impact_Score) as avg_impact_score,
                 MAX(Previous_Increase_Date) as last_increase_date,
-                MAX(Previous_Increase_Percentage) as last_increase,
+                MAX(Previous_Increase_Number) * 100 as last_increase,
                 STRING_AGG(DISTINCT Product_Line, ', ') as product_lines
             FROM filings
             WHERE State = '{state}'

--- a/tests/db/test_migration_extra_indexes.py
+++ b/tests/db/test_migration_extra_indexes.py
@@ -48,7 +48,8 @@ def test_migration_drops_extra_indexes(tmp_path):
             for row in conn.execute("PRAGMA table_info('filings')").fetchall()
         }
         assert info["Premium_Change_Number"].upper() == "DECIMAL(10,4)"
-        assert info["Previous_Increase_Percentage"].upper().startswith("VARCHAR")
+        assert "Previous_Increase_Number" in info
+        assert info["Previous_Increase_Number"].upper().startswith("DECIMAL")
         indexes = {
             row[0]
             for row in conn.execute(


### PR DESCRIPTION
## Summary
- migrate database column `Previous_Increase_Percentage` to numeric `Previous_Increase_Number`
- parse the new field when syncing from Airtable
- adjust health checks, analytics report and tests for new column

## Testing
- `python format_code.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_684333359ff0832bacfddc391689f888