### PR TITLE
Add incremental sync capability to demo

### DIFF
--- a/scripts/sync_demo.py
+++ b/scripts/sync_demo.py
@@ -1,5 +1,28 @@
+import json
+from datetime import datetime
+from pathlib import Path
+import argparse
+
 from serff_analytics.ingest.airtable_sync import AirtableSync
 from serff_analytics.db import DatabaseManager
+
+
+SYNC_FILE = Path(".last_sync.json")
+
+
+def get_last_sync_time() -> str | None:
+    """Return the ISO timestamp of the last successful sync if it exists."""
+    if SYNC_FILE.exists():
+        with SYNC_FILE.open("r") as f:
+            data = json.load(f)
+            return data.get("last_sync")
+    return None
+
+
+def save_sync_time(timestamp: str) -> None:
+    """Persist the timestamp of the latest sync."""
+    with SYNC_FILE.open("w") as f:
+        json.dump({"last_sync": timestamp}, f)
 
 
 def test_connection():
@@ -24,14 +47,16 @@ def test_connection():
         print(f"Airtable connection failed: {e}")
 
 
-def run_sync():
-    """Run the actual sync"""
-    print("\nRunning full sync...")
+def run_sync(since: datetime | None = None) -> dict:
+    """Run the sync and return the result dictionary."""
+    sync_type = "incremental" if since else "full"
+    print(f"\nRunning {sync_type} sync...")
+
     sync = AirtableSync()
-    result = sync.sync_data()
+    result = sync.sync_data(since=since)
 
     if result["success"]:
-        print(f"\n✅ Sync successful!")
+        print("\n✅ Sync successful!")
         print(f"Records processed: {result['records_processed']}")
         print(f"Total in database: {result['total_records']}")
 
@@ -45,10 +70,41 @@ def run_sync():
     else:
         print(f"\n❌ Sync failed: {result['error']}")
 
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Force full sync (ignore saved timestamp)",
+    )
+    parser.add_argument(
+        "--test-connection",
+        action="store_true",
+        help="Only test database and Airtable connections",
+    )
+    args = parser.parse_args()
+
+    if args.test_connection:
+        test_connection()
+        return
+
+    last_sync_str = None if args.full else get_last_sync_time()
+    since = datetime.fromisoformat(last_sync_str) if last_sync_str else None
+
+    if since:
+        print(f"🔄 Incremental sync since {last_sync_str}")
+    else:
+        print("🔄 Full sync")
+
+    result = run_sync(since)
+
+    if result.get("success"):
+        save_sync_time(datetime.utcnow().isoformat())
+        print("✅ Sync timestamp saved")
+
 
 if __name__ == "__main__":
-    test_connection()
-
-    response = input("\nConnection test complete. Run full sync? (y/n): ")
-    if response.lower() == "y":
-        run_sync()
+    main()

--- a/serff_analytics/ingest/airtable_sync.py
+++ b/serff_analytics/ingest/airtable_sync.py
@@ -35,11 +35,13 @@ class AirtableSync:
         """Call Airtable API methods with retries."""
         return func(*args, **kwargs)
 
+    LAST_MODIFIED_FIELD = "Last Modified"
+
     def _fetch_records(self, since: datetime | None = None):
         """Stream records from Airtable page by page."""
         params: dict[str, str] = {}
         if since:
-            params["filter_by_formula"] = f"LAST_MODIFIED_TIME() > '{since.isoformat()}'"
+            params["filter_by_formula"] = f"{{{self.LAST_MODIFIED_FIELD}}} > '{since.isoformat()}'"
 
         try:
             for page in self._safe_call(self.table.iterate, page_size=100, **params):

--- a/tests/ingest/test_airtable_sync.py
+++ b/tests/ingest/test_airtable_sync.py
@@ -40,7 +40,9 @@ def test_sync_only_updated_records(monkeypatch, db_path):
     args, kwargs = mock_iterate.call_args
     assert kwargs["page_size"] == 100
     assert "filter_by_formula" in kwargs
-    assert since.isoformat() in kwargs["filter_by_formula"]
+    formula = kwargs["filter_by_formula"]
+    assert since.isoformat() in formula
+    assert "{Last Modified}" in formula
 
     assert result["records_inserted"] == 2
     with sync.db.connection() as conn:


### PR DESCRIPTION
## Summary
- update `scripts/sync_demo.py` to keep the timestamp of the last sync
- allow running incremental or full syncs via a CLI flag
- save timestamp after each successful run
- use Airtable `{Last Modified}` field for incremental sync filters

## Testing
- `python format_code.py`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_b_6843432cdb48832bbffb137e48ffaf62