### PR TITLE
Add Airtable_Last_Modified column

### DIFF
--- a/add_airtable_timestamp_column.py
+++ b/add_airtable_timestamp_column.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Add Airtable_Last_Modified column to filings table"""
+import duckdb
+
+
+def main():
+    print("Adding Airtable_Last_Modified column...")
+
+    try:
+        conn = duckdb.connect('serff_analytics/data/insurance_filings.db')
+
+        # Check if column already exists
+        schema = conn.execute("PRAGMA table_info(filings)").fetchall()
+        columns = [col[1] for col in schema]
+
+        if 'Airtable_Last_Modified' in columns:
+            print("\u2713 Column already exists")
+        else:
+            # Add the column
+            conn.execute(
+                """
+                ALTER TABLE filings 
+                ADD COLUMN Airtable_Last_Modified TIMESTAMP
+                """
+            )
+            print("\u2713 Column added successfully")
+
+        # Verify
+        schema = conn.execute("PRAGMA table_info(filings)").fetchall()
+        for col in schema:
+            if col[1] == 'Airtable_Last_Modified':
+                print(f"\u2713 Verified: {col[1]} ({col[2]}) added to table")
+                break
+
+        conn.close()
+        print("\u2705 Step 1 completed successfully!")
+
+    except Exception as e:
+        print(f"\u274c Error: {e}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/serff_analytics/db/__init__.py
+++ b/serff_analytics/db/__init__.py
@@ -100,6 +100,10 @@ class DatabaseManager:
                     logger.info(
                         "Renamed Previous_Increase_Percentage to Previous_Increase_Number and converted to DECIMAL(10,4)"
                     )
+
+                if "Airtable_Last_Modified" not in columns:
+                    conn.execute("ALTER TABLE filings ADD COLUMN Airtable_Last_Modified TIMESTAMP")
+                    logger.info("Added Airtable_Last_Modified column")
         except duckdb.CatalogException:
             # Table doesn't exist yet; it will be created below
             pass
@@ -129,6 +133,7 @@ class DatabaseManager:
                 Population VARCHAR,
                 Impact_Score DECIMAL(10,2),
                 Renewals_Date DATE,
+                Airtable_Last_Modified TIMESTAMP,
                 Created_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 Updated_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
@@ -160,4 +165,5 @@ class DatabaseManager:
         - Policyholders_Affected_Number: Number of affected policyholders
         - Total_Written_Premium_Number: Total premium amount
         - SERFF_Tracking_Number: Regulatory tracking number
+        - Airtable_Last_Modified: Timestamp of last change in Airtable
         """

--- a/serff_analytics/ingest/airtable_sync.py
+++ b/serff_analytics/ingest/airtable_sync.py
@@ -83,11 +83,9 @@ class AirtableSync:
                             )
                             """
                         )
+                        columns = ", ".join(combined_df.columns)
                         conn.execute(
-                            """
-                            INSERT INTO filings
-                            SELECT * FROM airtable_import
-                            """
+                            f"INSERT INTO filings ({columns}) SELECT {columns} FROM airtable_import"
                         )
                         inserted = len(combined_df)
                     finally:


### PR DESCRIPTION
## Summary
- add migration script to create the Airtable_Last_Modified column
- update `DatabaseManager` schema and migrations
- adjust Airtable sync insert logic to specify column list

## Testing
- `python scripts/run_tests.py`
- `python format_code.py`

------
https://chatgpt.com/codex/tasks/task_b_684b3365b848832bbe8cd1c738f4657c