### PR TITLE
Capture Airtable last modified timestamp

### DIFF
--- a/serff_analytics/ingest/airtable_sync.py
+++ b/serff_analytics/ingest/airtable_sync.py
@@ -136,6 +136,19 @@ class AirtableSync:
         for record in page:
             fields = record["fields"]
 
+            # Parse the Last Modified field
+            last_modified = None
+            airtable_date = fields.get("Last Modified")
+
+            if airtable_date:
+                try:
+                    # Parse format: "5/14/2025 1:35pm"
+                    last_modified = datetime.strptime(airtable_date, "%m/%d/%Y %I:%M%p")
+                except ValueError:
+                    logger.warning(
+                        f"Could not parse date: {airtable_date} for record {record['id']}"
+                    )
+
             product_line = fields.get("Product Line", "")
             rate_change_raw = fields.get("Overall Rate Change Number")
             rate_change_parsed = self._parse_number(rate_change_raw, "Overall Rate Change Number")
@@ -186,6 +199,7 @@ class AirtableSync:
                 "Stated_Reasons": fields.get("Name", ""),
                 "Population": fields.get("Population", ""),
                 "Renewals_Date": self._parse_date(fields.get("Renewals Date")),
+                "Airtable_Last_Modified": last_modified,
                 "Created_At": datetime.now(),
                 "Updated_At": datetime.now(),
             }

--- a/test_timestamp_parsing.py
+++ b/test_timestamp_parsing.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Test that Airtable timestamps are being captured"""
+import duckdb
+
+# Run a sync first
+print("Running sync to populate timestamps...")
+# [Run your sync command here]
+
+# Check results
+conn = duckdb.connect('serff_analytics/data/insurance_filings.db')
+
+# Count records with timestamps
+total = conn.execute("SELECT COUNT(*) FROM filings").fetchone()[0]
+with_timestamp = conn.execute(
+    """
+    SELECT COUNT(*) FROM filings 
+    WHERE Airtable_Last_Modified IS NOT NULL
+    """
+).fetchone()[0]
+
+print(f"\nResults:")
+print(f"  Total records: {total}")
+print(f"  With timestamps: {with_timestamp}")
+print(f"  Missing timestamps: {total - with_timestamp}")
+
+# Show sample
+print("\nSample records with timestamps:")
+samples = conn.execute(
+    """
+    SELECT Record_ID, Company, Airtable_Last_Modified 
+    FROM filings 
+    WHERE Airtable_Last_Modified IS NOT NULL 
+    LIMIT 3
+    """
+).fetchall()
+
+for record in samples:
+    print(f"  {record[0]}: {record[1]} - Modified: {record[2]}")
+
+conn.close()


### PR DESCRIPTION
## Summary
- store Airtable "Last Modified" field when syncing
- provide a helper script for verifying timestamp capture

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_684c2620f344832bb9796d77f6621210